### PR TITLE
refactor(website): Support ARM64 and Nginx conf dir

### DIFF
--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -1,8 +1,16 @@
 # syntax=docker/dockerfile:1
-FROM strategicblue/cljs-builder:2024-05-05_05-08-12_9deb8180cecbf4ef7ee0c966917e7f80d349d1c1 as build
+
+FROM clojure:tools-deps-1.11.3.1456-bookworm-slim AS build
+
+RUN apt-get update && apt-get install -y apt-transport-https curl
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+RUN apt-get install -y nodejs
+RUN node -v
+
+COPY ./ /usr/app
 
 WORKDIR /usr/app
-COPY ./ /usr/app
+
 RUN npm install
 RUN npm run release
 
@@ -12,4 +20,4 @@ RUN rm -rf /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf /usr/share/nginx
 
 COPY --from=build /usr/app/public /usr/share/nginx/html
 COPY nginx.conf /etc/nginx
-COPY default.conf.template /etc/nginx/templates/
+COPY default.conf.template /etc/nginx/conf.d/default.conf

--- a/apps/website/nginx.conf
+++ b/apps/website/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
This enables local development for ARM64. The path for the copied `default.conf` is corrected too.

I've enabled Gzip too.
