### PR TITLE
fix(website): Rely on Nginx using templates

### DIFF
--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -14,10 +14,10 @@ WORKDIR /usr/app
 RUN npm install
 RUN npm run release
 
-FROM nginx:1.25.5
+FROM nginx:1.27.0-bookworm AS run
 
 RUN rm -rf /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf /usr/share/nginx/html
 
 COPY --from=build /usr/app/public /usr/share/nginx/html
 COPY nginx.conf /etc/nginx
-COPY default.conf.template /etc/nginx/conf.d/default.conf
+COPY default.conf.template /etc/nginx/templates/

--- a/apps/website/nginx.conf
+++ b/apps/website/nginx.conf
@@ -4,6 +4,7 @@ worker_processes  auto;
 error_log  /var/log/nginx/error.log notice;
 pid        /var/run/nginx.pid;
 
+daemon  off;
 
 events {
     worker_connections  1024;


### PR DESCRIPTION
With #74, I broke how Nginx uses `envsubst` on template files. This fixes that. It also bumps the Nginx version and sets the `daemon` setting to one more optimal for running in a container.
