### PR TITLE
fix(website): Remove dupe `daemon` directive

### DIFF
--- a/apps/website/nginx.conf
+++ b/apps/website/nginx.conf
@@ -4,8 +4,6 @@ worker_processes  auto;
 error_log  /var/log/nginx/error.log notice;
 pid        /var/run/nginx.pid;
 
-daemon  off;
-
 events {
     worker_connections  1024;
 }


### PR DESCRIPTION
`nginx: [emerg] "daemon" directive is duplicate in /etc/nginx/nginx.conf:7`

This only showed up on the provider.