### PR TITLE
refactor(api): Log to STDOUT instead

### DIFF
--- a/apps/api/config.ru
+++ b/apps/api/config.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './app.rb'
+require './app'
 
 require_relative 'rack_ougai_logger'
 

--- a/apps/api/config/puma.rb
+++ b/apps/api/config/puma.rb
@@ -2,12 +2,6 @@
 
 require 'fileutils'
 
-on_worker_boot do
-end
-
-before_fork do
-end
-
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
@@ -17,16 +11,10 @@ environment ENV['RACK_ENV'] || 'development'
 
 app_dir = File.expand_path('..', __dir__)
 
-shared_dir = File.join(app_dir, "shared")
 pid_dir = File.join(app_dir, "pids")
-logs_dir = File.join(app_dir, "logs")
 
-FileUtils.mkdir_p(shared_dir)
 FileUtils.mkdir_p(pid_dir)
-FileUtils.mkdir_p(logs_dir)
 
 pidfile File.join(pid_dir, "puma.pid")
-
-stdout_redirect File.join(logs_dir, "puma.stdout.log"), File.join(logs_dir, "puma.stderr.log"), true
 
 preload_app!


### PR DESCRIPTION
The log files aren't used in local or produdction environments.

There's 2 other small changes made to remove warnings about redundant code.
